### PR TITLE
Use cksum instead of shasum

### DIFF
--- a/zgen.zsh
+++ b/zgen.zsh
@@ -264,7 +264,7 @@ zgen-save() {
 
         local ages="$(stat -Lc "%Y" 2>/dev/null $ZGEN_RESET_ON_CHANGE || \
                       stat -Lf "%m" 2>/dev/null $ZGEN_RESET_ON_CHANGE)"
-        local shas="$(shasum -a 256 ${ZGEN_RESET_ON_CHANGE})"
+        local shas="$(cksum ${ZGEN_RESET_ON_CHANGE})"
 
         -zginit "read -rd '' ages <<AGES; read -rd '' shas <<SHAS"
         -zginit "$ages"
@@ -275,7 +275,7 @@ zgen-save() {
         -zginit 'if [[ -n "$ZGEN_RESET_ON_CHANGE" \'
         -zginit '   && "$(stat -Lc "%Y" 2>/dev/null $ZGEN_RESET_ON_CHANGE || \'
         -zginit '         stat -Lf "%m"             $ZGEN_RESET_ON_CHANGE)" != "$ages" \'
-        -zginit '   && "$(shasum -a 256             $ZGEN_RESET_ON_CHANGE)" != "$shas" ]]; then'
+        -zginit '   && "$(cksum                     $ZGEN_RESET_ON_CHANGE)" != "$shas" ]]; then'
         -zginit '   printf %s\\n '\''-- zgen: Files in $ZGEN_RESET_ON_CHANGE changed; resetting `init.zsh`...'\'
         -zginit '   zgen reset'
         -zginit 'fi'


### PR DESCRIPTION
cksum is a POSIX standard and therefor on most, if not all, Unix
flavors.

While it has more collisions than sha256, it is faster.  And the
collisions don't matter much for checking if the cache is old or not.

Closes: #72